### PR TITLE
Use modern day node version in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
+  - '4'
+  - '6'
+  - '8'
 sudo: false

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "devDependencies": {
     "jshint": "^2.5.5",
-    "mocha": "*",
+    "mocha": "^5.0.0",
     "uglify-js": "^2.4.15"
   }
 }


### PR DESCRIPTION
Looks like mocha does not support older node version due to a breaking change without the version bump in `request`. Instead of hunting down dependencies this can just run on newer versions of node.